### PR TITLE
Added link of DevOps Roadmap

### DIFF
--- a/content/post/DevOps_README/index.md
+++ b/content/post/DevOps_README/index.md
@@ -225,3 +225,9 @@ Continuous learning is a critical part of DevOps. Staying current is imperative.
 As Kubernetes starts to democratize compute in ways we all didn't think possible, it's worthwhile to familiarize yourself with Kubernetes.
 
 [Kubernetes README](https://kubereadme.com/): Books, tutorials, or other assets that would be useful to folks using Kubernetes.
+
+## DevOps Roadmap
+
+Step by step guide for DevOps, SRE or any other Operations Role.
+
+[DevOps Roadmap](https://roadmap.sh/devops): Complete guide to DevOps.


### PR DESCRIPTION
Hi @chris-short,

I came across your repository [devopsreadme.com](https://github.com/chris-short/devopsreadme.com) and found it to be a valuable resource for DevOps enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["DevOps Roadmap"](https://roadmap.sh/devops). I took the initiative to submit a ["Pull Request"](https://github.com/chris-short/devopsreadme.com/pull/6) adding it in a separate DevOps Roadmap section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz